### PR TITLE
Add ssh jump host in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3215,6 +3215,8 @@ ssh user@host cat /path/to/remotefile | diff /path/to/localfile -
 
 ```bash
 ssh -t reachable_host ssh unreachable_host
+# Short form -J[ump]:
+ssh -J reachable_host -J n_other_reachable_host unreachable_host
 ```
 
 ###### Run command over SSH on remote host


### PR DESCRIPTION
Instead of `ssh -t host1 ssh host2`, one can also specify a jump host.
I find this easier to memorize and more comfortable to use with multiple jumps.
A drawback is that with `ssh -t` teaches you a tool that's useful in a 
more general sense, hence I didn't want to remove it.